### PR TITLE
Lowering the priority of python.exe to reduce lags

### DIFF
--- a/stick_the_miner.py
+++ b/stick_the_miner.py
@@ -7,6 +7,8 @@ from eth_abi.packed import encode_abi_packed
 import random
 import time
 import logging, colorlog
+import psutil
+import os
 
 SALTCOLORLEVEL = 1
 RESULTCOLORLEVEL = 2
@@ -58,7 +60,8 @@ def get_salt() -> int:
     return random.randint(1, 2 ** 123)  # can probably go to 256 but 123 probably enough
 
 logger = setup_logger()
-
+core = psutil.Process(os.getpid())
+core.nice(psutil.BELOW_NORMAL_PRIORITY_CLASS)
 i = 0
 st = time.time()
 while True:
@@ -71,6 +74,6 @@ while True:
         logger.log(RESULTCOLORLEVEL, "done! here's the salt")
         logger.log(SALTCOLORLEVEL,str(salt))
         break
-    
+
     if i % 5000 == 0:
         print(f'iter {i}, {i / (time.time() - st)} avg iter per sec')


### PR DESCRIPTION
If a user is mining gems in the background while using other compute-intensive programs, the user might experience lags due to 100% CPU utilization. By lowering the priority of python.exe miner, other programs will have higher priorities. Thus, users would be less likely to experience lagging issues. 

Under a normal circumstance in which the CPU utilization is less than 100%, it should have no impact on iter/sec.

Before

![image](https://user-images.githubusercontent.com/57980116/132816835-0215b139-d1c4-4987-ace7-441ef2687dac.png)

After

![image](https://user-images.githubusercontent.com/57980116/132816806-fbc0afdf-71fc-41a0-a23a-df94b9df815d.png)
